### PR TITLE
fix: ensure player spawns on walkable tiles

### DIFF
--- a/spawn.test.js
+++ b/spawn.test.js
@@ -1,0 +1,55 @@
+const assert = require('assert');
+
+function stubCtx(){
+  return { setTransform:()=>{} };
+}
+function stubEl(){
+  return {
+    getContext: ()=>stubCtx(),
+    style:{},
+    addEventListener: ()=>{},
+    removeEventListener: ()=>{},
+    click: ()=>{},
+    textContent:'',
+    classList:{add:()=>{},remove:()=>{}}
+  };
+}
+
+global.window = { devicePixelRatio:1, addEventListener:()=>{} };
+global.document = {
+  getElementById: ()=>stubEl(),
+  addEventListener: ()=>{}
+};
+global.addEventListener = ()=>{};
+
+global.AudioContext = function(){
+  return {
+    createGain(){ return {connect:()=>{}, gain:{value:0}}; },
+    createOscillator(){ return {connect:()=>{}, frequency:{setValueAtTime:()=>{}}, start:()=>{}, stop:()=>{}, type:''}; },
+    currentTime:0
+  };
+};
+
+const game = require('./game.js');
+
+game.buildLevel();
+assert.notStrictEqual(
+  game.grid[Math.floor(game.pacman.y)][Math.floor(game.pacman.x)],
+  game.WALL,
+  'player overlaps wall on default spawn'
+);
+
+// move spawn marker onto a wall and reset spawn coords
+const idx = game.RAW.findIndex(r=>r.includes('p'));
+if (idx>=0) game.RAW[idx] = game.RAW[idx].replace('p','1');
+game.spawn.x = 0;
+game.spawn.y = 0;
+
+game.buildLevel();
+assert.notStrictEqual(
+  game.grid[Math.floor(game.pacman.y)][Math.floor(game.pacman.x)],
+  game.WALL,
+  'player overlaps wall when spawn on wall'
+);
+
+console.log('Spawn tests passed');


### PR DESCRIPTION
## Summary
- validate player spawn and snap to nearest walkable tile
- align spawn to grid and reposition if colliding with a wall
- add test ensuring player never spawns inside walls

## Testing
- `node spawn.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a0c9cd13883319da9e4bbede184ce