### PR TITLE
Prevent game speed-up on restart

### DIFF
--- a/game.js
+++ b/game.js
@@ -211,6 +211,7 @@ buildLevel();
 // ===== HUD
 let levelIndex=0, score=0, lives=3, paused=false, frightened=0, tick=0;
 let resumeMusic=false; // помнить состояние мелодии во время паузы
+let loopHandle=null;   // текущий кадр анимации
 function HUD(){ 
   document.getElementById('score').textContent=score;
   document.getElementById('lives').textContent=lives;
@@ -312,10 +313,13 @@ function startGame(){
     startMusic();
     btnMusic.textContent = `Мелодия ${melodyIndex+1} ⏹`;
   }
+  if (loopHandle){ cancelAnimationFrame(loopHandle); loopHandle=null; }
   loop();
 }
 function restart(){
-  score=0; lives=3; levelIndex=0; HUD(); buildLevel(); if (musicOn) startMusic(); paused=false; frightened=0; loop();
+  score=0; lives=3; levelIndex=0; HUD(); buildLevel(); if (musicOn) startMusic(); paused=false; frightened=0;
+  if (loopHandle){ cancelAnimationFrame(loopHandle); loopHandle=null; }
+  loop();
 }
 
 // ===== Движок тайлов
@@ -511,7 +515,11 @@ function draw(){
   }
 }
 
-function loop(){ if (paused){ draw(); return; } update(); draw(); requestAnimationFrame(loop); }
+function loop(){
+  if (paused){ draw(); loopHandle=null; return; }
+  update(); draw();
+  loopHandle = requestAnimationFrame(loop);
+}
 
 // инициализация HUD
 HUD();


### PR DESCRIPTION
## Summary
- avoid multiple animation loops by cancelling previous frame before starting or restarting

## Testing
- `node spawn.test.js`

------
https://chatgpt.com/codex/tasks/task_e_689a0ffe0adc83318e864aa5c8d2d757