### PR TITLE
feat: adapt layout for Telegram Mini App

### DIFF
--- a/game.js
+++ b/game.js
@@ -8,6 +8,7 @@ let DPR = Math.max(1, Math.min(2, window.devicePixelRatio || 1));
 const TILE = 24, COLS = 28, ROWS = 31;
 
 function fitCanvas(){
+  DPR = Math.max(1, Math.min(2, window.devicePixelRatio || 1));
   const w = COLS*TILE, h = ROWS*TILE;
   canvas.width  = Math.round(w * DPR);
   canvas.height = Math.round(h * DPR);
@@ -16,6 +17,7 @@ function fitCanvas(){
 }
 fitCanvas();
 addEventListener('resize', fitCanvas);
+globalThis.Telegram?.WebApp?.onEvent?.('viewportChanged', fitCanvas);
 
 // ===== Audio (минимум, чтобы не падало без жеста)
 let audioCtx, master, sfxGain, musicGain, musicTimer=null, musicOn=false, melodyIndex=0, audioEnabled=true;

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport"
-        content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+        content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
   <title>Bugman</title>
   <link rel="stylesheet" href="style.css">
 </head>
@@ -43,15 +43,17 @@
 <!-- Telegram Mini App SDK -->
 <script src="https://telegram.org/js/telegram-web-app.js"></script>
 <script>
-  // пробуем отключить вертикальные свайпы самого WebView
-  try {
-    Telegram?.WebApp?.ready?.();
-    Telegram?.WebApp?.expand?.();
-    Telegram?.WebApp?.disableVerticalSwipes?.();
-  } catch(_) {}
-  // на всякий случай фиксируем (0,0)
-  window.scrollTo(0,0);
-  addEventListener('scroll', ()=>scrollTo(0,0), {passive:true});
+  const tg = window.Telegram?.WebApp;
+  const isTg = tg && (tg.isExpanded || tg.platform === 'ios' || tg.platform === 'android');
+  if (isTg){
+    document.documentElement.classList.add('tg-app');
+    tg.ready();
+    tg.expand();
+    tg.disableVerticalSwipes?.();
+    // фиксируем позицию страницы
+    window.scrollTo(0,0);
+    addEventListener('scroll', () => scrollTo(0,0), { passive:true });
+  }
 </script>
 
 <!-- Игра -->

--- a/scoreboard.html
+++ b/scoreboard.html
@@ -2,7 +2,7 @@
 <html lang="ru">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
   <title>Bugman — рекорды</title>
   <link rel="stylesheet" href="style.css">
 </head>
@@ -26,6 +26,18 @@
 </div>
 
 <script src="https://telegram.org/js/telegram-web-app.js"></script>
+<script>
+  const tg = window.Telegram?.WebApp;
+  const isTg = tg && (tg.isExpanded || tg.platform === 'ios' || tg.platform === 'android');
+  if (isTg){
+    document.documentElement.classList.add('tg-app');
+    tg.ready();
+    tg.expand();
+    tg.disableVerticalSwipes?.();
+    window.scrollTo(0,0);
+    addEventListener('scroll', () => scrollTo(0,0), { passive:true });
+  }
+</script>
 <script src="scoreboard.js"></script>
 </body>
 </html>

--- a/scoreboard.js
+++ b/scoreboard.js
@@ -1,12 +1,4 @@
 (function(){
-  try {
-    Telegram?.WebApp?.ready?.();
-    Telegram?.WebApp?.expand?.();
-    Telegram?.WebApp?.disableVerticalSwipes?.();
-  } catch(_){ }
-  window.scrollTo(0,0);
-  addEventListener('scroll', ()=>scrollTo(0,0), {passive:true});
-
   const tbody = document.getElementById('records');
   let records = [];
   try {

--- a/style.css
+++ b/style.css
@@ -4,20 +4,30 @@
 }
 *{box-sizing:border-box}
 
-/* телега-мобайл: прибиваем скролл вообще */
+/* базовая разметка */
 html,body{
-  margin:0; height:100dvh;
+  margin:0;
   background:radial-gradient(1200px 500px at 70% -10%, #14264d 0%, #0a1124 55%, #070b16 100%);
   color:var(--text);
   font-family:Inter,system-ui,Segoe UI,Roboto,Arial,sans-serif;
-  overflow:hidden;                /* нет прокрутки */
-  overscroll-behavior:none;       /* нет резинки */
-  position:fixed; inset:0;        /* iOS: нет «протягивания» */
+}
+
+/* Telegram Mini App: полноэкранный режим без прокрутки */
+html.tg-app, html.tg-app body{
+  height:100dvh;
+  overflow:hidden;              /* нет прокрутки */
+  overscroll-behavior:none;     /* нет резинки */
+  position:fixed; inset:0;      /* iOS: нет «протягивания» */
+  touch-action:none;            /* запрет системных жестов */
 }
 
 .wrap{
   display:grid;
   grid-template-rows:auto 1fr auto auto;
+  min-height:100vh;
+}
+
+html.tg-app .wrap{
   height:100dvh;
   padding-left:env(safe-area-inset-left);  /* отступы под вырезы */
   padding-right:env(safe-area-inset-right);


### PR DESCRIPTION
## Summary
- add full-screen Telegram integration with safe-area support and scroll lock
- resize canvas on DPR changes and Telegram viewport events
- keep desktop/iPad layout with standard CSS

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node spawn.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a4defe77c8331b726e0055d7bd924