### PR TITLE
feat: sync leaderboard with backend and limit to top players

### DIFF
--- a/scoreboard.js
+++ b/scoreboard.js
@@ -1,13 +1,28 @@
-(function(){
+(async function(){
   const tbody = document.getElementById('records');
   let records = [];
+
+  // сначала пытаемся получить данные с сервера (если он настроен)
   try {
-    records = JSON.parse(localStorage.getItem('records')) || [];
-  } catch(_){ records = []; }
+    const resp = await fetch('/api/records');
+    if (resp.ok) {
+      records = await resp.json();
+    }
+  } catch(_){ }
+
+  // если сервер недоступен, используем локальное хранилище
+  if (!Array.isArray(records) || records.length===0){
+    try {
+      records = JSON.parse(localStorage.getItem('records')) || [];
+    } catch(_){ records = []; }
+  }
+
+  // сортируем по убыванию и берём только топ-20
   records.sort((a,b)=>b.score-a.score);
-  records.forEach((r,i)=>{
+  records.slice(0,20).forEach((r,i)=>{
     const tr = document.createElement('tr');
     tr.innerHTML = `<td class="pos">${i+1}</td><td class="name">${r.username}</td><td class="score">${r.score}</td>`;
     tbody.appendChild(tr);
   });
 })();
+


### PR DESCRIPTION
## Summary
- Save game results using player's Telegram name and push to `/api/records` while keeping a local fallback
- Automatically load leaderboard from backend/local storage, sort by score and show top‑20 players

## Testing
- `node spawn.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a524d94a48331a372d44d1f76aa30