### PR TITLE
fix: display player names on leaderboard

### DIFF
--- a/scoreboard.js
+++ b/scoreboard.js
@@ -21,7 +21,8 @@
   records.sort((a,b)=>b.score-a.score);
   records.slice(0,20).forEach((r,i)=>{
     const tr = document.createElement('tr');
-    tr.innerHTML = `<td class="pos">${i+1}</td><td class="name">${r.username}</td><td class="score">${r.score}</td>`;
+    const name = r.username || r.name || r.first_name || r.player || '';
+    tr.innerHTML = `<td class="pos">${i+1}</td><td class="name">${name}</td><td class="score">${r.score}</td>`;
     tbody.appendChild(tr);
   });
 })();


### PR DESCRIPTION
## Summary
- show player names in the leaderboard even if records use different fields for name

## Testing
- `node spawn.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a546dd8e88331a2a67775016cee0d