### PR TITLE
Prompt restart when lives exhausted

### DIFF
--- a/game.js
+++ b/game.js
@@ -474,6 +474,9 @@ function update(){
         lives=Math.max(0,lives-1); HUD();
         if (lives<=0 && !gameOver){
           paused=true; gameOver=true; saveRecord(score);
+          setTimeout(()=>{
+            if (confirm('Жизни закончились. Начать заново?')) restart();
+          }, 0);
         }
         else {
           // респавн в центр (не в стену)


### PR DESCRIPTION
## Summary
- Show confirm dialog when player loses all lives and offer to restart

## Testing
- `node spawn.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a559f907c83318924c6bf9363c5b3