### PR TITLE
Add game-over overlay and preserve melody on restart

### DIFF
--- a/spawn.test.js
+++ b/spawn.test.js
@@ -5,15 +5,16 @@ function stubCtx(){
 }
 function stubEl(){
   return {
-    getContext: ()=>stubCtx(),
-    style:{},
-    addEventListener: ()=>{},
-    removeEventListener: ()=>{},
-    click: ()=>{},
-    textContent:'',
-    classList:{add:()=>{},remove:()=>{}}
-  };
-}
+      getContext: ()=>stubCtx(),
+      style:{},
+      addEventListener: ()=>{},
+      removeEventListener: ()=>{},
+      click: ()=>{},
+      textContent:'',
+      classList:{add:()=>{},remove:()=>{}},
+      querySelector: ()=>({textContent:''})
+    };
+  }
 
 global.window = { devicePixelRatio:1, addEventListener:()=>{} };
 global.document = {


### PR DESCRIPTION
## Summary
- Show a restart overlay instead of a confirm dialog when the player loses all lives.
- Remember music state so the melody resumes automatically after restarting.
- Extend test stubs for new DOM queries.

## Testing
- `node spawn.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a577bc2348331a790196d600f350f