### PR TITLE
Fix scoreboard API path

### DIFF
--- a/game.js
+++ b/game.js
@@ -236,7 +236,7 @@ async function saveRecord(finalScore){
     }
 
     // попытка отправить рекорд на бэкенд (если он настроен)
-    await fetch('/api/records', {
+    await fetch('api/records', {
       method: 'POST',
       headers: {'Content-Type':'application/json'},
       body: JSON.stringify({ username:name, score:finalScore })

--- a/scoreboard.js
+++ b/scoreboard.js
@@ -4,7 +4,7 @@
 
   // сначала пытаемся получить данные с сервера (если он настроен)
   try {
-    const resp = await fetch('/api/records');
+    const resp = await fetch('api/records');
     if (resp.ok) {
       records = await resp.json();
     }


### PR DESCRIPTION
## Summary
- use relative `api/records` path in scoreboard fetch
- save records to relative API endpoint

## Testing
- `node spawn.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a600e339883318fc04a86084a0424