### PR TITLE
feat(front): подключение глобального лидерборда к API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,17 @@
 - `style.css` — стили
 - `game.js` — логика игры (без внешних ассетов)
 
+## Конфиг API
+
+Базовый адрес API задаётся в `config.js` (по умолчанию `https://bugman-bot.onrender.com`).
+Для отладки можно переопределить глобальной переменной `API_BASE_OVERRIDE` перед подключением скриптов.
+
+## Проверка работы API
+
+1. Сыграйте партию — после завершения очки отправятся POST-запросом на `${API_BASE}/score`.
+2. Откройте «Рекорды» — список загрузится с `${API_BASE}/leaderboard`.
+3. Можно напрямую запросить `GET ${API_BASE}/leaderboard` и увидеть JSON со списком рекордов.
+
 Деплой на GitHub Pages:
 1) Создай репозиторий и залей эти три файла в корень ветки `main`.
 2) Settings → Pages → Source: `Deploy from a branch`. Branch: `main` / `(root)`. Save.

--- a/config.js
+++ b/config.js
@@ -1,0 +1,9 @@
+// prod-адрес API
+let API_BASE = "https://bugman-bot.onrender.com";
+// Для отладки разреши переопределение через глобал:
+if (typeof window !== 'undefined' && window.API_BASE_OVERRIDE) {
+  // например, window.API_BASE_OVERRIDE = "http://localhost:8080"
+  // перед подключением скриптов
+  API_BASE = window.API_BASE_OVERRIDE;
+}
+export { API_BASE };

--- a/game.js
+++ b/game.js
@@ -235,13 +235,27 @@ async function saveRecord(finalScore){
       }
     }
 
-    // попытка отправить рекорд на бэкенд (если он настроен)
-    await fetch('api/records', {
-      method: 'POST',
-      headers: {'Content-Type':'application/json'},
-      body: JSON.stringify({ username:name, score:finalScore })
-    }).catch(()=>{}); // тихо игнорируем ошибки сети
+    submitScore(finalScore);
   } catch(_){ }
+}
+
+async function submitScore(finalScore) {
+  try {
+    const { API_BASE } = await import('./config.js');
+    const initData = Telegram?.WebApp?.initData || '';
+    const res = await fetch(`${API_BASE}/score`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ initData, score: Number(finalScore) || 0 })
+    });
+    const data = await res.json();
+    if (data.ok === true) {
+      Telegram?.WebApp?.showPopup?.({ message: 'Очки сохранены' });
+    }
+  } catch (e) {
+    console.error('submitScore error', e);
+    Telegram?.WebApp?.showPopup?.({ message: 'Не удалось сохранить очки' });
+  }
 }
 
 // ===== Управление

--- a/index.html
+++ b/index.html
@@ -41,11 +41,12 @@
 </div>
 
 <!-- Telegram Mini App SDK -->
-<script src="https://telegram.org/js/telegram-web-app.js"></script>
-<script src="init.js"></script>
+  <script src="https://telegram.org/js/telegram-web-app.js"></script>
+  <script src="init.js"></script>
+  <script type="module" src="config.js"></script>
 
-<!-- Игра -->
-<script src="./game.js"></script>
+  <!-- Игра -->
+  <script src="./game.js"></script>
 
 <!-- Доп. блокировка системных жестов в области игры -->
 <script>

--- a/init.js
+++ b/init.js
@@ -2,6 +2,11 @@ const tg = window.Telegram?.WebApp;
 const IS_TG = !!tg;
 const IS_IOS_TG = IS_TG && tg.platform === 'ios';
 
+if (window.Telegram && Telegram.WebApp) {
+  Telegram.WebApp.ready();
+  // Telegram.WebApp.expand(); // опционально
+}
+
 function applySafeArea(){
   if (!window.Telegram?.WebApp) return;              // снаружи Telegram — ничего не менять
   const tg = window.Telegram.WebApp;
@@ -17,8 +22,6 @@ function flipIfOverflow(el){
   if (r.right > window.innerWidth - 8) el.classList.add('align-left'); else el.classList.remove('align-left');
 }
 
-tg?.ready();
-tg?.expand();
 tg?.onEvent?.('viewportChanged', applySafeArea);
 window.addEventListener('resize', applySafeArea);
 applySafeArea();

--- a/scoreboard.html
+++ b/scoreboard.html
@@ -7,26 +7,30 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-<div class="app">
-  <header>
-    <div class="brand"><div class="dot"></div><h1>Bugman</h1></div>
-    <div class="hud">
-      <a href="index.html" class="btn">Назад ↩</a>
-    </div>
-  </header>
-  <main class="records">
-    <table>
-      <thead>
-        <tr><th>#</th><th>Игрок</th><th>Очки</th></tr>
-      </thead>
-      <tbody id="records"></tbody>
-    </table>
-  </main>
-  <footer>© 2025 — Bugman.</footer>
-</div>
+  <div class="app">
+    <header>
+      <div class="brand"><div class="dot"></div><h1>Bugman</h1></div>
+      <div class="hud">
+        <a href="index.html" class="btn">Назад ↩</a>
+      </div>
+    </header>
+    <main class="records">
+      <div id="loading" class="loading">Загрузка...</div>
+      <div id="empty" class="empty" style="display:none;">Пока нет рекордов</div>
+      <table id="recordsTable" style="display:none;">
+        <thead>
+          <tr><th>#</th><th>Игрок</th><th>Очки</th></tr>
+        </thead>
+        <tbody id="records"></tbody>
+      </table>
+      <div class="debug"><small>API: <span id="apiBase"></span></small></div>
+    </main>
+    <footer>© 2025 — Bugman.</footer>
+  </div>
 
-<script src="https://telegram.org/js/telegram-web-app.js"></script>
-<script src="init.js"></script>
-<script src="scoreboard.js"></script>
+  <script src="https://telegram.org/js/telegram-web-app.js"></script>
+  <script src="init.js"></script>
+  <script type="module" src="config.js"></script>
+  <script type="module" src="scoreboard.js"></script>
 </body>
 </html>

--- a/scoreboard.js
+++ b/scoreboard.js
@@ -1,29 +1,55 @@
-(async function(){
+import { API_BASE } from "./config.js";
+
+async function loadLeaderboard(limit = 100, offset = 0) {
   const tbody = document.getElementById('records');
-  let records = [];
-
-  // сначала пытаемся получить данные с сервера (если он настроен)
+  const table = document.getElementById('recordsTable');
+  const empty = document.getElementById('empty');
+  const loading = document.getElementById('loading');
   try {
-    const resp = await fetch('api/records');
-    if (resp.ok) {
-      records = await resp.json();
+    loading.style.display = 'block';
+    table.style.display = 'none';
+    empty.style.display = 'none';
+    const res = await fetch(`${API_BASE}/leaderboard?limit=${limit}&offset=${offset}`);
+    const { items } = await res.json();
+    tbody.innerHTML = '';
+    if (Array.isArray(items) && items.length > 0) {
+      items.forEach((r, i) => {
+        const tr = document.createElement('tr');
+        const pos = document.createElement('td');
+        pos.className = 'pos';
+        pos.textContent = i + 1 + offset;
+        const nameTd = document.createElement('td');
+        nameTd.className = 'name';
+        const display = r.display_name || '';
+        if (r.username) {
+          const a = document.createElement('a');
+          a.href = `https://t.me/${r.username}`;
+          a.textContent = display;
+          a.target = '_blank';
+          nameTd.appendChild(a);
+        } else {
+          nameTd.textContent = display;
+        }
+        const scoreTd = document.createElement('td');
+        scoreTd.className = 'score';
+        scoreTd.textContent = r.score;
+        tr.append(pos, nameTd, scoreTd);
+        tbody.appendChild(tr);
+      });
+      table.style.display = 'table';
+    } else {
+      empty.style.display = 'block';
     }
-  } catch(_){ }
-
-  // если сервер недоступен, используем локальное хранилище
-  if (!Array.isArray(records) || records.length===0){
-    try {
-      records = JSON.parse(localStorage.getItem('records')) || [];
-    } catch(_){ records = []; }
+  } catch (e) {
+    console.error('loadLeaderboard error', e);
+    empty.textContent = 'Не удалось загрузить рекорды';
+    empty.style.display = 'block';
+  } finally {
+    loading.style.display = 'none';
   }
+}
 
-  // сортируем по убыванию и берём только топ-20
-  records.sort((a,b)=>b.score-a.score);
-  records.slice(0,20).forEach((r,i)=>{
-    const tr = document.createElement('tr');
-    const name = r.username || r.name || r.first_name || r.player || '';
-    tr.innerHTML = `<td class="pos">${i+1}</td><td class="name">${name}</td><td class="score">${r.score}</td>`;
-    tbody.appendChild(tr);
-  });
-})();
-
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('apiBase').textContent = API_BASE;
+  loadLeaderboard();
+});

--- a/style.css
+++ b/style.css
@@ -104,3 +104,5 @@ footer{
 .records .pos{text-align:right;color:var(--muted);width:40px}
 .records .score{text-align:right;font-weight:700}
 .records .name{font-weight:700}
+.records .loading,.records .empty{width:100%;max-width:480px;text-align:center;padding:20px;color:var(--muted)}
+.records .debug{margin-top:8px;font-size:12px;color:var(--muted)}


### PR DESCRIPTION
## Summary
- add configurable API base with override support
- send game scores to backend and display leaderboard from API
- show current API endpoint on records page

## Testing
- `node spawn.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a6b92dabc833194a16218ed6dee83