### PR TITLE
fix(front): raw initData submit and dev verify

### DIFF
--- a/api.js
+++ b/api.js
@@ -10,12 +10,31 @@ function toast(message) {
 }
 
 let lastSubmitAt = 0;
+let devVerified = false;
+
+async function verifyInitData(initData) {
+  if (!globalThis.window?.DEBUG || devVerified) return;
+  devVerified = true;
+  try {
+    const res = await fetch(`${API_BASE}/debug/verify`, {
+      method: "POST",
+      mode: "cors",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ initData })
+    });
+    const data = await res.json();
+    console.log("initData verify:", data);
+  } catch (e) {
+    console.warn("initData verify failed", e);
+  }
+}
 export async function submitScore(score) {
   const initData = Telegram?.WebApp?.initData || "";
   if (!initData) {
     toast("Откройте игру внутри Telegram");
     return;
   }
+  await verifyInitData(initData);
   const now = Date.now();
   if (now - lastSubmitAt < 2000) return;
   lastSubmitAt = now;


### PR DESCRIPTION
## Summary
- verify init data once in dev mode
- keep score submission using raw `initData` with proper fallback

## Testing
- `node spawn.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689af4093bcc833191b5454f9aba3245