### PR TITLE
Improve scoreboard display and alignment

### DIFF
--- a/scoreboard.js
+++ b/scoreboard.js
@@ -1,16 +1,6 @@
 import { API_BASE } from "./config.js";
 import { submitScore, toast } from "./api.js";
 
-function escapeHTML(str = "") {
-  return str.replace(/[&<>"']/g, c => ({
-    '&': '&amp;',
-    '<': '&lt;',
-    '>': '&gt;',
-    '"': '&quot;',
-    "'": '&#39;'
-  }[c]));
-}
-
 const tbody = document.getElementById('records');
 const table = document.getElementById('recordsTable');
 const empty = document.getElementById('empty');
@@ -26,20 +16,24 @@ function renderTable(items, offset = 0) {
       pos.textContent = i + 1 + offset;
       const nameTd = document.createElement('td');
       nameTd.className = 'name';
-      const name = item.display_name || item.username || 'Player';
+      const defaultName = `Player ${(item.id ?? item.user_id ?? i + 1 + offset).toString().padStart(4, '0')}`;
+      let name = item.username || item.first_name || item.last_name || defaultName;
+      if (name.length > 24) {
+        name = name.slice(0, 24) + '…';
+      }
       if (item.username) {
         const a = document.createElement('a');
         a.href = `https://t.me/${item.username}`;
         a.target = '_blank';
         a.rel = 'noopener';
-        a.innerHTML = escapeHTML(name);
+        a.textContent = name;
         nameTd.appendChild(a);
       } else {
-        nameTd.innerHTML = escapeHTML(name);
+        nameTd.textContent = name;
       }
       const scoreTd = document.createElement('td');
       scoreTd.className = 'score';
-      scoreTd.textContent = item.best_score;
+      scoreTd.textContent = item.best_score ?? 0;
       tr.append(pos, nameTd, scoreTd);
       tbody.appendChild(tr);
     });

--- a/style.css
+++ b/style.css
@@ -97,11 +97,11 @@ footer{
   overflow:auto; /* чтобы длинные списки прокручивались */
 }
 .records table{width:100%;border-collapse:collapse}
-.records th,.records td{padding:8px 12px}
-.records th{background:#0b1430;color:var(--accent);text-align:left;position:sticky;top:0;z-index:1}
+.records th,.records td{padding:8px 12px;text-align:center}
+.records th{background:#0b1430;color:var(--accent);position:sticky;top:0;z-index:1}
 .records tr:nth-child(odd){background:#0b1430}
 .records tr:nth-child(even){background:#101a34}
-.records .pos{text-align:right;color:var(--muted);width:40px}
-.records .score{text-align:right;font-weight:700}
+.records .pos{color:var(--muted);width:40px}
+.records .score{font-weight:700}
 .records .name{font-weight:700}
 .records .loading,.records .empty{width:100%;text-align:center;padding:20px;color:var(--muted)}


### PR DESCRIPTION
## Summary
- Use `best_score` for leaderboard points and prioritize player name fields
- Truncate long names and center scoreboard columns for cleaner layout

## Testing
- `node spawn.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689b1beda0908331937a8c5724c66307