### PR TITLE
ui: remove bottom help text and copyright

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,9 +26,6 @@
   <main id="game">
     <canvas id="canvas" width="672" height="744" tabindex="0" aria-label="Игровое поле Bugman"></canvas>
   </main>
-
-  <div class="legend">Стрелки / WASD, свайпы (включая тачпад). Выход за край — вход с противоположного края.</div>
-  <footer>© 2025 — Bugman.</footer>
 </div>
 
 <!-- стартовая плашка -->

--- a/scoreboard.html
+++ b/scoreboard.html
@@ -24,7 +24,6 @@
         <tbody id="records"></tbody>
       </table>
     </main>
-    <footer>© 2025 — Bugman.</footer>
   </div>
 
   <script src="https://telegram.org/js/telegram-web-app.js"></script>

--- a/style.css
+++ b/style.css
@@ -19,7 +19,7 @@ html,body{
 
 .app{
   display:grid;
-  grid-template-rows:auto 1fr auto auto;
+  grid-template-rows:auto 1fr;
   min-height:var(--vh);
   padding-top:calc(var(--safe-top) + 12px);         /* отступ под вырез/хедер */
   padding-right:calc(var(--safe-right) + 8px);      /* чтобы не пряталось под … */
@@ -62,11 +62,6 @@ canvas{
   overscroll-behavior:none;
 }
 
-.legend{padding:0 14px 14px;color:var(--muted);text-align:center;font-size:12px}
-footer{
-  padding:10px 14px;
-  color:#8aa0c6;text-align:center;font-size:12px
-}
 
 .dropdown, .modal {
   top: calc(var(--safe-top) + 8px) !important;


### PR DESCRIPTION
## Summary
- Remove gameplay control hint and copyright footer from game screen and scoreboard
- Clean up unused legend/footer styles and update grid layout

## Testing
- `node spawn.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689b1e840d9c8331b0c0d3fad7ff4f21