### PR TITLE
Silence rate-limit popups and avoid duplicate score submits

### DIFF
--- a/api.js
+++ b/api.js
@@ -36,7 +36,7 @@ export async function submitScore(score) {
   }
   await verifyInitData(initData);
   const now = Date.now();
-  if (now - lastSubmitAt < 2000) return;
+  if (now - lastSubmitAt < 5000) return;
   lastSubmitAt = now;
   try {
     // send raw initData without any encoding or manipulation
@@ -46,11 +46,16 @@ export async function submitScore(score) {
       body: JSON.stringify({ initData, score: Number(score) || 0 })
     });
     const data = await res.json();
+    if (res.status === 429 || data?.error === "rate_limited") {
+      window.loadLeaderboard?.();
+      return;
+    }
     if (!res.ok || data?.ok === false) {
       const reason = data?.reason || data?.error || `HTTP ${res.status}`;
       toast(`Не удалось сохранить: ${reason}`);
       return;
     }
+    window.loadLeaderboard?.();
     // toast("Очки сохранены");
   } catch (e) {
     toast("Не удалось сохранить: сеть/сервер");

--- a/scoreboard.js
+++ b/scoreboard.js
@@ -1,5 +1,5 @@
 import { API_BASE } from "./config.js";
-import { submitScore, toast } from "./api.js";
+import { toast } from "./api.js";
 
 const tbody = document.getElementById('records');
 const table = document.getElementById('recordsTable');
@@ -61,17 +61,9 @@ export async function loadLeaderboard(limit = 100, offset = 0) {
     loading.style.display = 'none';
   }
 }
-
-let submitted = false;
-function ensurePlayer() {
-  if (submitted) return;
-  submitted = true;
-  const lastKnownScore = localStorage.getItem('lastKnownScore');
-  submitScore(lastKnownScore ?? 0);
-}
+window.loadLeaderboard = loadLeaderboard;
 
 document.addEventListener('DOMContentLoaded', () => {
-  ensurePlayer();
   loadLeaderboard();
 });
 


### PR DESCRIPTION
## Summary
- Increase score submit debounce to 5s and silently handle rate-limited responses
- Refresh leaderboard after successful or rate-limited submissions
- Remove automatic score submission from records page and expose `loadLeaderboard` globally

## Testing
- `node spawn.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689b1fec1fec8331bf5c53f7758513e9